### PR TITLE
Add ability to configure CDMI servlet

### DIFF
--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -45,6 +45,12 @@
 
     <context:annotation-config/>
 
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="location">
+           <value>cdmi.properties</value>
+        </property>
+    </bean>
+
     <!-- Register autowired components -->
 
     <context:component-scan base-package="org.snia.cdmiserver"/>
@@ -108,12 +114,12 @@
     <!-- Application Objects -->
 
     <bean id="containerDao" class="org.snia.cdmiserver.dao.filesystem.ContainerDaoImpl">
-        <property name="baseDirectoryName" value="/data"/>
+        <property name="baseDirectoryName" value="${cdmi.base-directory}"/>
         <property name="recreate" value="false"/>
     </bean>
 
     <bean id="dataObjectDao" class="org.snia.cdmiserver.dao.filesystem.DataObjectDaoImpl">
-        <property name="baseDirectoryName" value="/data"/>
+        <property name="baseDirectoryName" value="${cdmi.base-directory}"/>
         <property name="containerDao" ref="containerDao"/>
     </bean>
 

--- a/src/main/webapp/cdmi.properties
+++ b/src/main/webapp/cdmi.properties
@@ -1,0 +1,1 @@
+cdmi.base-directory=/data


### PR DESCRIPTION
Motivation:

The reference implementation provides no mechanism with which
the admin can configure its behaviour.  In particular, the
base directory is hard-coded as '/data'

Modification:

Add the cdmi.properties file that contains configuration options
which are available as options through spring dependency injection.

Result:

The target directory may be configured by the admin.
