### PR TITLE
Quieten default output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,31 +3,31 @@
 <!--
  * Copyright (c) 2010, Sun Microsystems, Inc.
  * Copyright (c) 2010, The Storage Networking Industry Association.
- *  
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- *  
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
- * Neither the name of The Storage Networking Industry Association (SNIA) nor 
- * the names of its contributors may be used to endorse or promote products 
+ *
+ * Neither the name of The Storage Networking Industry Association (SNIA) nor
+ * the names of its contributors may be used to endorse or promote products
  * derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *  THE POSSIBILITY OF SUCH DAMAGE.
 -->
 
@@ -149,7 +149,7 @@
       </plugin>
     </plugins>
   </build>
- 
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -185,6 +185,22 @@
       <artifactId>httpclient</artifactId>
       <version>4.0.1</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.13</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>${logback.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <version>${logback.version}</version>
     </dependency>
 
     <!-- Needed by integration tests -->
@@ -230,5 +246,6 @@
     <integration-test.webapp-directory>${integration-test.base-directory}/webapp</integration-test.webapp-directory>
     <integration-test.target-directory>${integration-test.base-directory}/data</integration-test.target-directory>
     <jetty.version>9.2.2.v20140723</jetty.version>
+    <logback.version>1.0.12</logback.version>
   </properties>
 </project>

--- a/src/main/java/org/snia/cdmiserver/dao/filesystem/CapabilityDaoImpl.java
+++ b/src/main/java/org/snia/cdmiserver/dao/filesystem/CapabilityDaoImpl.java
@@ -1,31 +1,31 @@
     /*
  * Copyright (c) 2010, Sun Microsystems, Inc.
  * Copyright (c) 2010, The Storage Networking Industry Association.
- *  
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- *  
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
- * Neither the name of The Storage Networking Industry Association (SNIA) nor 
- * the names of its contributors may be used to endorse or promote products 
+ *
+ * Neither the name of The Storage Networking Industry Association (SNIA) nor
+ * the names of its contributors may be used to endorse or promote products
  * derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *  THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.snia.cdmiserver.dao.filesystem;
@@ -33,6 +33,8 @@ package org.snia.cdmiserver.dao.filesystem;
 import org.snia.cdmiserver.dao.CapabilityDao;
 import org.snia.cdmiserver.model.Capability;
 import org.snia.cdmiserver.util.ObjectID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -41,6 +43,8 @@ import org.snia.cdmiserver.util.ObjectID;
  * </p>
  */
 public class CapabilityDaoImpl implements CapabilityDao {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CapabilityDaoImpl.class);
 
     // -------------------------------------------------------------- Properties
     /**
@@ -68,10 +72,9 @@ public class CapabilityDaoImpl implements CapabilityDao {
     public Capability findByPath(String path) {
         Capability capability = new Capability();
 
-        System.out.print("In Capability.findByPath, path is: ");
-        System.out.println(path);
+        LOG.trace("In Capability.findByPath, path is: {}", path);
         if (path.equals("container/")) {
-            System.out.println("Container Capabilities");
+            LOG.trace("Container Capabilities");
             // Container Capabilities
             // cdmi_list_children = true
             // cdmi_list_children_range = unset until implemented
@@ -94,7 +97,7 @@ public class CapabilityDaoImpl implements CapabilityDao {
             capability.setParentURI("cdmi_capabilities/");
             capability.setParentID(ROOTobjectID);
         } else if (path.equals("container/default/")) {
-            System.out.println("Default Container Capabilities");
+            LOG.trace("Default Container Capabilities");
             capability.getMetadata().put("cdmi_list_children", "true");
             capability.getMetadata().put("cdmi_read_metadata", "true");
             capability.getMetadata().put("cdmi_modify_metadata", "true");
@@ -108,7 +111,7 @@ public class CapabilityDaoImpl implements CapabilityDao {
 
         } else if (path.equals("dataobject/")) {
             // Data Object Capabilities
-            System.out.println("Data Object Capabilities");
+            LOG.trace("Data Object Capabilities");
             // cdmi_read_value = true
             // cdmi_read_value_range = unset initially, then true when implemented
             // cdmi_read_metadata = true
@@ -128,7 +131,7 @@ public class CapabilityDaoImpl implements CapabilityDao {
             capability.setParentID(ROOTobjectID);
         } else {
             // System Capabilities
-            System.out.println("System Capabilities");
+            LOG.trace("System Capabilities");
             // cdmi_domains = later version true
             // cdmi_export_occi_iscsi = true for demo?
             // cdmi_metadata_maxitems, cdmi_metadata_maxsize = TBD based on our limits

--- a/src/main/java/org/snia/cdmiserver/dao/filesystem/ContainerDaoImpl.java
+++ b/src/main/java/org/snia/cdmiserver/dao/filesystem/ContainerDaoImpl.java
@@ -1,31 +1,31 @@
 /*
  * Copyright (c) 2010, Sun Microsystems, Inc.
  * Copyright (c) 2010, The Storage Networking Industry Association.
- *  
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- *  
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
- * Neither the name of The Storage Networking Industry Association (SNIA) nor 
- * the names of its contributors may be used to endorse or promote products 
+ *
+ * Neither the name of The Storage Networking Industry Association (SNIA) nor
+ * the names of its contributors may be used to endorse or promote products
  * derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *  THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.snia.cdmiserver.dao.filesystem;
@@ -44,6 +44,8 @@ import org.snia.cdmiserver.exception.BadRequestException;
 import org.snia.cdmiserver.exception.NotFoundException;
 import org.snia.cdmiserver.model.Container;
 import org.snia.cdmiserver.util.ObjectID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -51,6 +53,8 @@ import org.snia.cdmiserver.util.ObjectID;
  * </p>
  */
 public class ContainerDaoImpl implements ContainerDao {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ContainerDaoImpl.class);
 
     //
     // Properties and Dependency Injection Methods
@@ -61,7 +65,7 @@ public class ContainerDaoImpl implements ContainerDao {
      * <p>
      * Set the base directory name for our local storage.
      * </p>
-     * 
+     *
      * @param baseDirectory
      *            The new base directory name
      */
@@ -77,7 +81,7 @@ public class ContainerDaoImpl implements ContainerDao {
      * base directory to be erased on first access. Default value for this flag is
      * <code>false</code>.
      * </p>
-     * 
+     *
      * @param recreate
      *            The new recreate flag value
      */
@@ -196,8 +200,7 @@ public class ContainerDaoImpl implements ContainerDao {
                 out.write(containerRequest.toJson(true)); // Save it
                 out.close();
             } catch (Exception ex) {
-                ex.printStackTrace();
-                System.out.println("Exception while writing: " + ex);
+                LOG.error("Exception while writing", ex);
                 throw new IllegalArgumentException("Cannot write container fields file @"
                                                    + path
                                                    + " error : "
@@ -288,8 +291,7 @@ public class ContainerDaoImpl implements ContainerDao {
                     out.write(containerRequest.toJson(true)); // Save it
                     out.close();
                 } catch (Exception ex) {
-                    ex.printStackTrace();
-                    System.out.println("Exception while writing: " + ex);
+                    LOG.error("Exception while writing", ex);
                     throw new IllegalArgumentException("Cannot write container fields file @"
                                                        + path
                                                        + " error : "
@@ -352,10 +354,10 @@ public class ContainerDaoImpl implements ContainerDao {
     @Override
     public Container findByPath(String path) {
 
-        System.out.println("In ContainerDAO.findByPath : " + path);
-        
+        LOG.trace("In ContainerDAO.findByPath : {}", path);
+
         File directory = absoluteFile(path);
-        
+
         if (!directory.exists()) {
             throw new NotFoundException("Path '"
                                         + directory.getAbsolutePath()
@@ -397,7 +399,7 @@ public class ContainerDaoImpl implements ContainerDao {
      * <p>
      * Return a {@link File} instance for the container fields file object.
      * </p>
-     * 
+     *
      * @param path
      *            Path of the requested container.
      */
@@ -415,30 +417,26 @@ public class ContainerDaoImpl implements ContainerDao {
         for (int i = 0; i <= tokens.length - 2; i++) {
             parentContainerName += tokens[i] + "/";
         }
-        System.out.println("Path = " + path);
-        System.out.println("Parent Container Name = "
-                           + parentContainerName
-                           + " Container Name == "
-                           + containerName);
+        LOG.trace("Path = {}", path);
+        LOG.trace("Parent Container Name = {} Container Name == {}",
+                           parentContainerName, containerName);
 
 
         File baseDirectory1, parentContainerDirectory, containerFieldsFile;
         try {
-            System.out.println("baseDirectory = " + baseDirectoryName);
+            LOG.trace("baseDirectory = {}", baseDirectoryName);
             baseDirectory1 = new File(baseDirectoryName + "/");
-            System.out
-                    .println("Base Directory Absolute Path = " + baseDirectory1.getAbsolutePath());
+            LOG.trace("Base Directory Absolute Path = {}", baseDirectory1.getAbsolutePath());
             parentContainerDirectory = new File(baseDirectory1, parentContainerName);
             //
-            System.out.println("Parent Container Absolute Path = "
-                               + parentContainerDirectory.getAbsolutePath());
+            LOG.trace("Parent Container Absolute Path = {}",
+                               parentContainerDirectory.getAbsolutePath());
             //
             containerFieldsFile = new File(parentContainerDirectory, containerFieldsFileName);
-            System.out.println("Container Metadata File Path = "
-                               + containerFieldsFile.getAbsolutePath());
+            LOG.trace("Container Metadata File Path = {}",
+                               containerFieldsFile.getAbsolutePath());
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception while building File objects: " + ex);
+            LOG.error("Exception while building File objects: ", ex);
             throw new IllegalArgumentException("Cannot build Object @" + path + " error : " + ex);
         }
         return containerFieldsFile;
@@ -448,7 +446,7 @@ public class ContainerDaoImpl implements ContainerDao {
      * <p>
      * Return a {@link Container} instance for the container fields.
      * </p>
-     * 
+     *
      * @param containerFieldsFile
      *            File object for the container fields file.
      */
@@ -457,20 +455,19 @@ public class ContainerDaoImpl implements ContainerDao {
         try {
             FileInputStream in = new FileInputStream(containerFieldsFile.getAbsolutePath());
             int inpSize = in.available();
-            System.out.println("Container fields file size:" + inpSize);
+            LOG.trace("Container fields file size: {}", inpSize);
 
             byte[] inBytes = new byte[inpSize];
             in.read(inBytes);
 
             containerFields.fromJson(inBytes, true);
             String mds = new String(inBytes);
-            System.out.println("Container fields read were:" + mds);
+            LOG.trace("Container fields read were: {}", mds);
 
             // Close the output stream
             in.close();
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception while reading: " + ex);
+            LOG.error("Exception while reading: ", ex);
             throw new IllegalArgumentException("Cannot read container fields file error : " + ex);
         }
         return containerFields;
@@ -481,7 +478,7 @@ public class ContainerDaoImpl implements ContainerDao {
      * Return a {@link File} instance for the file or directory at the specified path from our base
      * directory.
      * </p>
-     * 
+     *
      * @param path
      *            Path of the requested file or directory.
      */
@@ -500,7 +497,7 @@ public class ContainerDaoImpl implements ContainerDao {
      * Return a {@link File} instance for the base directory, erasing any previous content on first
      * use if the <code>recreate</code> flag has been set.
      * </p>
-     * 
+     *
      * @exception IllegalArgumentException
      *                if we cannot create the base directory
      */
@@ -523,29 +520,29 @@ public class ContainerDaoImpl implements ContainerDao {
      * <p>
      * Return the {@link Container} identified by the specified <code>path</code>.
      * </p>
-     * 
+     *
      * @param container
      *            The requested container with persisted fields
      * @param directory
      *            Directory of the requested container
      * @param path
      *            Path of the requested container
-     * 
+     *
      * @exception NotFoundException
      *                if the specified path does not identify a valid resource
      * @exception IllegalArgumentException
      *                if the specified path identifies a data object instead of a container
      */
     private Container completeContainer(Container container, File directory, String path) {
-        System.out.println("In ContainerDaoImpl.Container, path is: " + path);
+        LOG.trace("In ContainerDaoImpl.Container, path is: {}", path);
 
-        System.out.println("In ContainerDaoImpl.Container, absolute path is: "
-                           + directory.getAbsolutePath());
+        LOG.trace("In ContainerDaoImpl.Container, absolute path is: {}",
+                           directory.getAbsolutePath());
 
-        
+
         container.setObjectType("application/cdmi-container");
-        
-        
+
+
 
         //
         // Derive ParentURI
@@ -560,10 +557,8 @@ public class ContainerDaoImpl implements ContainerDao {
             for (int i = 0; i <= tokens.length - 2; i++) {
                 parentURI += tokens[i] + "/";
             }
-            System.out.println("In ContainerDaoImpl.Container, ParentURI = "
-                               + parentURI
-                               + " Container Name = "
-                               + containerName);
+            LOG.trace("In ContainerDaoImpl.Container, ParentURI = {}"
+                               + " Container Name = {}", parentURI, containerName);
             // Check for illegal top level container names
             if (parentURI.matches("/") && containerName.startsWith("cdmi")) {
                 throw new BadRequestException("Root container names must not start with cdmi");
@@ -596,7 +591,7 @@ public class ContainerDaoImpl implements ContainerDao {
             String childrange = "0-" + lastindex;
             container.setChildrenrange(childrange);
         }
-        
+
         return container;
     }
 
@@ -604,7 +599,7 @@ public class ContainerDaoImpl implements ContainerDao {
      * <p>
      * Delete the specified directory, after first recursively deleting any contents within it.
      * </p>
-     * 
+     *
      * @param directory
      *            {@link File} identifying the directory to be deleted
      */

--- a/src/main/java/org/snia/cdmiserver/dao/filesystem/DataObjectDaoImpl.java
+++ b/src/main/java/org/snia/cdmiserver/dao/filesystem/DataObjectDaoImpl.java
@@ -1,31 +1,31 @@
 /*
  * Copyright (c) 2010, Sun Microsystems, Inc.
  * Copyright (c) 2010, The Storage Networking Industry Association.
- *  
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- *  
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
- * Neither the name of The Storage Networking Industry Association (SNIA) nor 
- * the names of its contributors may be used to endorse or promote products 
+ *
+ * Neither the name of The Storage Networking Industry Association (SNIA) nor
+ * the names of its contributors may be used to endorse or promote products
  * derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *  THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.snia.cdmiserver.dao.filesystem;
@@ -43,6 +43,8 @@ import org.snia.cdmiserver.exception.BadRequestException;
 import org.snia.cdmiserver.exception.ConflictException;
 import org.snia.cdmiserver.model.DataObject;
 import org.snia.cdmiserver.util.ObjectID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -51,6 +53,8 @@ import org.snia.cdmiserver.util.ObjectID;
  */
 public class DataObjectDaoImpl implements DataObjectDao {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ContainerDaoImpl.class);
+
     // -------------------------------------------------------------- Properties
     private String baseDirectoryName = null;
 
@@ -58,7 +62,7 @@ public class DataObjectDaoImpl implements DataObjectDao {
 
     public void setBaseDirectoryName(String baseDirectoryName) {
         this.baseDirectoryName = baseDirectoryName;
-        System.out.println("******* Base Directory = " + baseDirectoryName);
+        LOG.trace("******* Base Directory = {}", baseDirectoryName);
     }
 
     /**
@@ -116,21 +120,20 @@ public class DataObjectDaoImpl implements DataObjectDao {
         //
         File objFile, baseDirectory, containerDirectory, metadataFile;
         try {
-            System.out.println("baseDirectory = " + baseDirectoryName);
+            LOG.trace("baseDirectory = {}", baseDirectoryName);
             baseDirectory = new File(baseDirectoryName + "/");
-            System.out.println("Base Directory Absolute Path = " + baseDirectory.getAbsolutePath());
+            LOG.trace("Base Directory Absolute Path = {}", baseDirectory.getAbsolutePath());
             containerDirectory = new File(baseDirectory, containerName);
             // File directory = absoluteFile(path);
-            System.out.println("Container Absolute Path = " + containerDirectory.getAbsolutePath());
+            LOG.trace("Container Absolute Path = {}", containerDirectory.getAbsolutePath());
             //
             metadataFile = new File(containerDirectory, metadataFileName);
-            System.out.println("Metadada File Path = " + metadataFile.getAbsolutePath());
+            LOG.trace("Metadada File Path = {}", metadataFile.getAbsolutePath());
             objFile = new File(baseDirectory, path);
             // File directory = absoluteFile(path);
-            System.out.println("Object Absolute Path = " + objFile.getAbsolutePath());
+            LOG.trace("Object Absolute Path = {}", objFile.getAbsolutePath());
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception while writing: " + ex);
+            LOG.error("Exception while writing: ", ex);
             throw new IllegalArgumentException("Cannot write Object @" + path + " error : " + ex);
         }
         // check for container
@@ -178,7 +181,7 @@ public class DataObjectDaoImpl implements DataObjectDao {
             // Close the output stream
             out.close();
             // write metadata file
-            System.out.println("metadataFile : " + metadataFileName);
+            LOG.trace("metadataFile : {}", metadataFileName);
             fstream = new FileWriter(metadataFile.getAbsolutePath());
             out = new BufferedWriter(fstream);
             out.write(dObj.metadataToJson()); // Save it
@@ -186,13 +189,12 @@ public class DataObjectDaoImpl implements DataObjectDao {
             out.close();
             //
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception while writing: " + ex);
+            LOG.error("Exception while writing: ", ex);
             throw new IllegalArgumentException("Cannot write Object @" + path + " error : " + ex);
         }
         return dObj;
     }
-    
+
 
     @Override
     public DataObject createNonCDMIByPath(String path, String contentType, DataObject dObj) throws Exception {
@@ -202,21 +204,20 @@ public class DataObjectDaoImpl implements DataObjectDao {
         //
         File objFile, baseDirectory, containerDirectory, metadataFile;
         try {
-            System.out.println("createNonCDMIByPath baseDirectory = " + baseDirectoryName);
+            LOG.trace("createNonCDMIByPath baseDirectory = {}", baseDirectoryName);
             baseDirectory = new File(baseDirectoryName + "/");
-            System.out.println("createNonCDMIByPath Base Directory Absolute Path = " + baseDirectory.getAbsolutePath());
+            LOG.trace("createNonCDMIByPath Base Directory Absolute Path = {}", baseDirectory.getAbsolutePath());
             containerDirectory = new File(baseDirectory, containerName);
             // File directory = absoluteFile(path);
-            System.out.println("createNonCDMIByPath Container Absolute Path = " + containerDirectory.getAbsolutePath());
+            LOG.trace("createNonCDMIByPath Container Absolute Path = {}", containerDirectory.getAbsolutePath());
             //
             metadataFile = new File(containerDirectory, metadataFileName);
-            System.out.println("createNonCDMIByPath Metadada File Path = " + metadataFile.getAbsolutePath());
+            LOG.trace("createNonCDMIByPath Metadada File Path = {}", metadataFile.getAbsolutePath());
             objFile = new File(baseDirectory, path);
             // File directory = absoluteFile(path);
-            System.out.println("createNonCDMIByPath Object Absolute Path = " + objFile.getAbsolutePath());
+            LOG.trace("createNonCDMIByPath Object Absolute Path = {}", objFile.getAbsolutePath());
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception while writing: " + ex);
+            LOG.error("Exception while writing: ", ex);
             throw new IllegalArgumentException("Cannot write Object @" + path + " error : " + ex);
         }
         // check for container
@@ -253,7 +254,7 @@ public class DataObjectDaoImpl implements DataObjectDao {
             dObj.setMetadata("metadataFileName", metadataFile.getAbsolutePath());
 
             dObj.setMimetype(contentType);
-            System.out.println("createNonCDMIByPath Content Type : " + contentType);
+            LOG.trace("createNonCDMIByPath Content Type : {}", contentType);
 
             dObj.setMetadata("mimetype", contentType);
             //
@@ -263,7 +264,7 @@ public class DataObjectDaoImpl implements DataObjectDao {
             // Close the output stream
             out.close();
             // write metadata file
-            System.out.println("metadataFile : " + metadataFileName);
+            LOG.trace("metadataFile : {}", metadataFileName);
             fstream = new FileWriter(metadataFile.getAbsolutePath());
             out = new BufferedWriter(fstream);
             out.write(dObj.metadataToJson()); // Save it
@@ -271,13 +272,12 @@ public class DataObjectDaoImpl implements DataObjectDao {
             out.close();
             //
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception while writing: " + ex);
+            LOG.error("Exception while writing: ", ex);
             throw new IllegalArgumentException("Cannot write Object @" + path + " error : " + ex);
         }
         return dObj;
     }
-    
+
 
 
     @Override
@@ -292,7 +292,7 @@ public class DataObjectDaoImpl implements DataObjectDao {
 
     @Override
     public DataObject findByPath(String path) {
-        System.out.println("In findByPath : " + path);
+        LOG.trace("In findByPath : {}", path);
         //
         String metadataFileName = getmetadataFileName(path);
         String containerName = getcontainerName(path);
@@ -300,13 +300,12 @@ public class DataObjectDaoImpl implements DataObjectDao {
         // Check for metadata file
         File objFile, metadataFile, baseDirectory;
         try {
-            System.out.println("baseDirectory = " + baseDirectoryName);
+            LOG.trace("baseDirectory = {}", baseDirectoryName);
             baseDirectory = new File(baseDirectoryName + "/" + containerName);
             metadataFile = new File(baseDirectory, metadataFileName);
-            System.out.println("Metadata Absolute Path = " + metadataFile.getAbsolutePath());
+            LOG.trace("Metadata Absolute Path = {}", metadataFile.getAbsolutePath());
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception in findByPath : " + ex);
+            LOG.error("Exception in findByPath : ", ex);
             throw new IllegalArgumentException("Cannot get Object @" + path + " error : " + ex);
         }
         if (!metadataFile.exists()) {
@@ -314,13 +313,12 @@ public class DataObjectDaoImpl implements DataObjectDao {
         }
         // Check for object file
         try {
-            System.out.println("baseDirectory = " + baseDirectoryName);
+            LOG.trace("baseDirectory = {}", baseDirectoryName);
             baseDirectory = new File(baseDirectoryName + "/");
             objFile = new File(baseDirectory, path);
-            System.out.println("Object Absolute Path = " + objFile.getAbsolutePath());
+            LOG.trace("Object Absolute Path = {}", objFile.getAbsolutePath());
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception in findByPath : " + ex);
+            LOG.error("Exception in findByPath : ", ex);
             throw new IllegalArgumentException("Cannot get Object @" + path + " error : " + ex);
         }
         if (!objFile.exists()) {
@@ -350,8 +348,7 @@ public class DataObjectDaoImpl implements DataObjectDao {
             // Close the output stream
             in.close();
         } catch (Exception ex) {
-            ex.printStackTrace();
-            System.out.println("Exception while reading: " + ex);
+            LOG.error("Exception while reading: ", ex);
             throw new IllegalArgumentException("Cannot read Object @" + path + " error : " + ex);
         }
 

--- a/src/main/java/org/snia/cdmiserver/model/Container.java
+++ b/src/main/java/org/snia/cdmiserver/model/Container.java
@@ -1,31 +1,31 @@
 /*
  * Copyright (c) 2010, Sun Microsystems, Inc.
  * Copyright (c) 2010, The Storage Networking Industry Association.
- *  
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- *  
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
- * Neither the name of The Storage Networking Industry Association (SNIA) nor 
- * the names of its contributors may be used to endorse or promote products 
+ *
+ * Neither the name of The Storage Networking Industry Association (SNIA) nor
+ * the names of its contributors may be used to endorse or promote products
  * derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *  THE POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -43,6 +43,9 @@ import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.snia.cdmiserver.dao.filesystem.ContainerDaoImpl;
 import org.snia.cdmiserver.exception.BadRequestException;
 
 /**
@@ -51,6 +54,7 @@ import org.snia.cdmiserver.exception.BadRequestException;
  * </p>
  */
 public class Container {
+    private static final Logger LOG = LoggerFactory.getLogger(Container.class);
 
     // Container creation fields
     private Map<String, String> metadata = new HashMap<String, String>();
@@ -266,7 +270,7 @@ public class Container {
                     key = jp.getCurrentName();
                     tolkein = jp.nextToken();
                     String value = jp.getText();
-                    System.out.println("   Key = " + key + " : Value = " + value);
+                    LOG.trace("   Key = {} : Value = {}", key, value);
                     this.getMetadata().put(key, value);
                     // jp.nextToken();
                 }// while
@@ -281,31 +285,31 @@ public class Container {
             } else if ("capabilitiesURI".equals(key)) {// process capabilitiesURI
                 jp.nextToken();
                 String value2 = jp.getText();
-                System.out.println("Key : " + key + " Val : " + value2);
+                LOG.trace("Key : {} Val : {}", key, value2);
                 this.setCapabilitiesURI(value2);
             } else if ("domainURI".equals(key)) {// process domainURI
                 jp.nextToken();
                 String value2 = jp.getText();
-                System.out.println("Key : " + key + " Val : " + value2);
+                LOG.trace("Key : {} Val : {}", key, value2);
                 this.setDomainURI(value2);
             } else if ("move".equals(key)) {// process move
                 jp.nextToken();
                 String value2 = jp.getText();
-                System.out.println("Key : " + key + " Val : " + value2);
+                LOG.trace("Key : {} Val : {}", key, value2);
                 this.setMove(value2);
             } else {
                 if (fromFile) { // accept rest of key-values
                     if ("objectID".equals(key)) { // process value
                         jp.nextToken();
                         String value2 = jp.getText();
-                        System.out.println("Key : " + key + " Val : " + value2);
+                        LOG.trace("Key : {} Val : {}", key, value2);
                         this.setObjectID(value2);
                     } else {
-                        System.out.println("Invalid Key : " + key);
+                        LOG.warn("Invalid Key : {}", key);
                         throw new BadRequestException("Invalid Key : " + key);
                     } // inner if
                 } else {
-                    System.out.println("Invalid Key : " + key);
+                    LOG.warn("Invalid Key : {}", key);
                     throw new BadRequestException("Invalid Key : " + key);
                 }
             }

--- a/src/main/java/org/snia/cdmiserver/model/DataObject.java
+++ b/src/main/java/org/snia/cdmiserver/model/DataObject.java
@@ -1,31 +1,31 @@
 /*
  * Copyright (c) 2010, Sun Microsystems, Inc.
  * Copyright (c) 2010, The Storage Networking Industry Association.
- *  
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- *  
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
- * Neither the name of The Storage Networking Industry Association (SNIA) nor 
- * the names of its contributors may be used to endorse or promote products 
+ *
+ * Neither the name of The Storage Networking Industry Association (SNIA) nor
+ * the names of its contributors may be used to endorse or promote products
  * derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *  THE POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -41,6 +41,8 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonToken;
 import org.snia.cdmiserver.exception.BadRequestException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <p>
@@ -48,6 +50,7 @@ import org.snia.cdmiserver.exception.BadRequestException;
  * </p>
  */
 public class DataObject {
+    private static final Logger LOG = LoggerFactory.getLogger(DataObject.class);
 
     // DataObject creation fields
     private String mimetype;
@@ -299,54 +302,54 @@ public class DataObject {
                     key = jp.getCurrentName();
                     tolkein = jp.nextToken();
                     String value = jp.getText();
-                    System.out.println("   Key = " + key + " : Value = " + value);
+                    LOG.trace("   Key = {} : Value = {}", key, value);
                     this.setMetadata(key, value);
                     // jp.nextToken();
                 }// while
             } else if ("value".equals(key)) { // process value
                 jp.nextToken();
                 String value1 = jp.getText();
-                System.out.println("Key : " + key + " Val : " + value1);
+                LOG.trace("Key : {} Val : {}", key, value1);
                 this.setValue(value1);
             } else if ("mimetype".equals(key)) { // process mimetype
                 jp.nextToken();
                 String value2 = jp.getText();
-                System.out.println("Key : " + key + " Val : " + value2);
+                LOG.trace("Key : {} Val : {}", key, value2);
                 this.setMimetype(value2);
             } else {
                 if (fromFile) { // accept rest of key-values
                     if ("objectType".equals(key)) {
                         jp.nextToken();
                         String value2 = jp.getText();
-                        System.out.println("Key : " + key + " Val : " + value2);
+                        LOG.trace("Key : {} Val : {}", key, value2);
                         this.setObjectType(value2);
                     } else if ("capabilitiesURI".equals(key)) {
                         jp.nextToken();
                         String value2 = jp.getText();
-                        System.out.println("Key : " + key + " Val : " + value2);
+                        LOG.trace("Key : {} Val : {}", key, value2);
                         this.setCapabilitiesURI(value2);
                     } else if ("objectID".equals(key)) { // process value
                         jp.nextToken();
                         String value2 = jp.getText();
-                        System.out.println("Key : " + key + " Val : " + value2);
+                        LOG.trace("Key : {} Val : {}", key, value2);
                         this.setObjectID(value2);
                     } else if ("valueRange".equals(key)) { // process value
                         jp.nextToken();
                         String value2 = jp.getText();
-                        System.out.println("Key : " + key + " Val : " + value2);
+                        LOG.trace("Key : {} Val : {}", key, value2);
                         this.setValuerange(value2);
                     } else {
-                        System.out.println("Invalid Key : " + key);
+                        LOG.warn("Invalid Key : {}", key);
                         throw new BadRequestException("Invalid Key : " + key);
                     } // inner if
                 } else {
-                    System.out.println("Invalid Key : " + key);
+                    LOG.warn("Invalid Key : {}", key);
                     throw new BadRequestException("Invalid Key : " + key);
                 }
             }
         }
     }
-    
+
 
     public void setValue(byte[] bytes) {
         this.value = new String(bytes);

--- a/src/main/java/org/snia/cdmiserver/resource/CapabilityResource.java
+++ b/src/main/java/org/snia/cdmiserver/resource/CapabilityResource.java
@@ -1,35 +1,38 @@
 /*
  * Copyright (c) 2010, Sun Microsystems, Inc.
  * Copyright (c) 2010, The Storage Networking Industry Association.
- *  
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- *  
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
- * Neither the name of The Storage Networking Industry Association (SNIA) nor 
- * the names of its contributors may be used to endorse or promote products 
+ *
+ * Neither the name of The Storage Networking Industry Association (SNIA) nor
+ * the names of its contributors may be used to endorse or promote products
  * derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *  THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 package org.snia.cdmiserver.resource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
@@ -48,6 +51,7 @@ import org.snia.cdmiserver.util.MediaTypes;
 
 @Path("/cdmi_capabilities{path:.*}")
 public class CapabilityResource {
+    private static final Logger LOG = LoggerFactory.getLogger(CapabilityResource.class);
 
     /**
      * <p>
@@ -72,15 +76,14 @@ public class CapabilityResource {
      * <p>
      * [Chapter 12] Read a Capability Object (CDMI Content Type)
      * </p>
-     * 
+     *
      * @param path
      *            Path to the existing container
      */
     @GET
     @Produces(MediaTypes.CAPABILITY)
     public Response getCapabilityDao(@PathParam("path") String path) {
-        System.out.print("In CapabilityResource.getCapabilityDao, path is: ");
-        System.out.println(path);
+        LOG.trace("In CapabilityResource.getCapabilityDao, path is: {}", path);
         Capability capability = capabilityDao.findByPath(path);
         return Response.ok(capability).type(MediaTypes.CAPABILITY).build();
     }

--- a/src/main/java/org/snia/cdmiserver/resource/ObjectIdResource.java
+++ b/src/main/java/org/snia/cdmiserver/resource/ObjectIdResource.java
@@ -1,35 +1,38 @@
 /*
  * Copyright (c) 2010, Sun Microsystems, Inc.
  * Copyright (c) 2010, The Storage Networking Industry Association.
- *  
- * Redistribution and use in source and binary forms, with or without 
+ *
+ * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
- * Redistributions of source code must retain the above copyright notice, 
+ *
+ * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- *  
- * Redistributions in binary form must reproduce the above copyright notice, 
- * this list of conditions and the following disclaimer in the documentation 
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
- * Neither the name of The Storage Networking Industry Association (SNIA) nor 
- * the names of its contributors may be used to endorse or promote products 
+ *
+ * Neither the name of The Storage Networking Industry Association (SNIA) nor
+ * the names of its contributors may be used to endorse or promote products
  * derived from this software without specific prior written permission.
- *  
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  *  THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 package org.snia.cdmiserver.resource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -45,7 +48,6 @@ import javax.ws.rs.core.Response;
 import org.snia.cdmiserver.dao.DataObjectDao;
 import org.snia.cdmiserver.model.DataObject;
 import org.snia.cdmiserver.util.MediaTypes;
-import org.snia.cdmiserver.resource.PathResource;
 
 /**
  * <p>
@@ -56,6 +58,7 @@ import org.snia.cdmiserver.resource.PathResource;
 @Path("cdmi_objectid/{objectId}")
 // How will URL get here ? TBD
 public class ObjectIdResource {
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectIdResource.class);
 
     private DataObjectDao dObjDao;// = new DataObjectDaoImpl();
 
@@ -68,15 +71,15 @@ public class ObjectIdResource {
      * <p>
      * [7.5.8] Get Container By Object Id
      * </p>
-     * 
+     *
      * @param objectId
      *            Object ID of the requested {@link Container}
      */
 
-    
+
     /*
      * @GET
-     * 
+     *
      * @Produces(MediaTypes.CONTAINER) public Response getContainer(@PathParam("objectId") String
      * objectId) { throw new UnsupportedOperationException("ObjectIdResource.getContainer()"); }
      */
@@ -85,7 +88,7 @@ public class ObjectIdResource {
      * <p>
      * [7.4.8] Get Data Object By Object Id
      * </p>
-     * 
+     *
      * @param objectId
      *            Object ID of the requested {@link DataObject}
      */
@@ -96,10 +99,12 @@ public class ObjectIdResource {
             @PathParam("objectId") String objectId,
             @Context HttpHeaders headers) {
         // print headers for debug
-        for (String hdr : headers.getRequestHeaders().keySet()) {
-            System.out.println(hdr + " - " + headers.getRequestHeader(hdr));
+        if (LOG.isDebugEnabled()) {
+            for (String hdr : headers.getRequestHeaders().keySet()) {
+                LOG.debug("{} - {}", hdr, headers.getRequestHeader(hdr));
+            }
         }
-        System.out.println("Get Object ID = " + objectId);
+        LOG.debug("Get Object ID = {}", objectId);
 
         String path = "object_id/" + objectId;
         PathResource pathResource = new PathResource();
@@ -115,11 +120,14 @@ public class ObjectIdResource {
             @PathParam("objectId") String objectId,
             byte[] bytes) {
         // print headers for debug
-        for (String hdr : headers.getRequestHeaders().keySet()) {
-            System.out.println(hdr + " - " + headers.getRequestHeader(hdr));
+        if (LOG.isDebugEnabled()) {
+            for (String hdr : headers.getRequestHeaders().keySet()) {
+                LOG.debug("{} - {}", hdr, headers.getRequestHeader(hdr));
+            }
+
+            String inBuffer = new String(bytes);
+            LOG.debug("Object Id = {} {}", objectId, inBuffer);
         }
-        String inBuffer = new String(bytes);
-        System.out.println("Object Id = " + objectId + "\n" + inBuffer);
         PathResource pathResource = new PathResource();
         String objectPath = "object_id" + "/" + objectId;
         Response resp = pathResource.putDataObject(headers,objectPath,bytes);
@@ -135,11 +143,13 @@ public class ObjectIdResource {
             @PathParam("objectId") String objectId,
             byte[] bytes) {
         // print headers for debug
-        for (String hdr : headers.getRequestHeaders().keySet()) {
-            System.out.println(hdr + " - " + headers.getRequestHeader(hdr));
+        if (LOG.isDebugEnabled()) {
+            for (String hdr : headers.getRequestHeaders().keySet()) {
+                LOG.debug("{} - {}", hdr, headers.getRequestHeader(hdr));
+            }
+            String inBuffer = new String(bytes);
+            LOG.debug("Object Id = {} {}", objectId, inBuffer);
         }
-        String inBuffer = new String(bytes);
-        System.out.println("Object Id = " + objectId + "\n" + inBuffer);
         PathResource pathResource = new PathResource();
         String objectPath = "object_id" + "/" + objectId;
         Response resp = pathResource.postDataObject(objectPath,bytes);

--- a/src/main/java/org/snia/cdmiserver/util/ObjectID.java
+++ b/src/main/java/org/snia/cdmiserver/util/ObjectID.java
@@ -30,11 +30,15 @@
 
 package org.snia.cdmiserver.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * 
+ *
  * @author ksankar May 29,2010
  */
 public class ObjectID {
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectID.class);
 
     public static String getObjectID(int eNum) {
         byte objBytes[] = new byte[24];
@@ -76,7 +80,9 @@ public class ObjectID {
         for (int i = 0; i < objBytes.length; i++) {
             crc.update(objBytes[i]);
         }
-        System.out.println("CRC=" + Integer.toHexString(crc.value));
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("CRC={}", Integer.toHexString(crc.value));
+        }
         objBytes[6] = (byte) (crc.value >> 8);
         objBytes[7] = (byte) crc.value;
         //

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Motivation:

The code contains large number of `println` statements.  While this
provides a wealth of information, under some deployments this may
provide too much information and, without a logging framework, tuning
what information to display impossible.

Modification:

Introduce logging via slf4j.  This provides an abstract mechanism to
route logging information to some back-end that decides whether the
message is to be logged.  Logback is introduced as a core dependency
but deployments may override this and introduce a logging tunnel
to integrate logging with their chosen solution.

Result:

The output is quieter by default and may be tunned.  The code also
now supports better integration with existing logging solutions.
