### PR TITLE
Target Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,10 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>3.5</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 
@@ -161,7 +161,7 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-      <version>2.2.5</version>
+      <version>2.3.11</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Motivation:

Currently the code compilation targets Java v6.  This restriction
prevents the code from using the many language and library benefits that
Java v8 brings.

At the same time both Java v6 and Java v7 have reached their EOL.  With
no further (public) updates expected, it seems unlikely that
well-managed services will be using either Java v6 or Java v7.  This
makes the above restriction pointless.

Modification:

This patch provides a minimal change to support targeting Java v8.
There is no use of Java v8 features yet.

Result:

The compiles and verifies using Java v8.
