### PR TITLE
Add additional functional tests against capabilities

### DIFF
--- a/src/test/java/org/snia/cdmiserver/CapabilityTests.java
+++ b/src/test/java/org/snia/cdmiserver/CapabilityTests.java
@@ -42,6 +42,7 @@ import static org.snia.cdmiserver.Matchers.*;
 
 import java.net.URISyntaxException;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 import static org.snia.cdmiclient.Request.Method.GET;
 
@@ -80,19 +81,98 @@ public class CapabilityTests
         assertThat(headers, hasHeader("Content-Type", "application/cdmi-capability"));
 
         HttpEntity entity = response.getEntity();
-        assertThat(entity, hasJsonValueAt("$.capabilities.domains").of("false"));
         assertThat(entity, hasJsonStringAt("$.objectID"));
+        assertThat(entity, hasJsonValueAt("$.parentURI").of("/"));
         assertThat(entity, hasJsonStringAt("$.parentID"));
         assertThat(entity, hasJsonObjectAt("$.capabilities"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.domains").of("false"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_metadata_maxitems").of("1024"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_metadata_maxsize").of("4096"));
         assertThat(entity, hasJsonListAt("$.children"));
         assertThat(entity, hasJsonValueAt("$.children[0]").of("container"));
         assertThat(entity, hasJsonValueAt("$.children[1]").of("dataobject"));
 
-        // REVISIT: should these be a numerical value?
-        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_metadata_maxitems").of("1024"));
-        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_metadata_maxsize").of("4096"));
+    }
 
-        // FIXME: following assertion currently fails.
-        //assertThat(response, hasJsonAt("$.parentURI").of("/"));
+
+    @Test
+    public void shouldShowContainerCapability() throws Exception
+    {
+        HttpResponse response = client.request(GET, "/cdmi_capabilities/container/")
+                .withAccept("application/cdmi-capability")
+                .send();
+
+
+        assertThat(response.getStatusLine(), hasStatusCode(200));
+
+        Header[] headers = response.getAllHeaders();
+        assertThat(headers, hasHeader("Content-Type", "application/cdmi-capability"));
+
+        HttpEntity entity = response.getEntity();
+        assertThat(entity, hasJsonStringAt("$.objectID"));
+        assertThat(entity, hasJsonValueAt("$.parentURI").of("cdmi_capabilities/"));
+        assertThat(entity, hasJsonStringAt("$.parentID"));
+        assertThat(entity, hasJsonObjectAt("$.capabilities"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_read_metadata").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_create_dataobject").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_create_container").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_modify_metadata").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_list_children").of("true"));
+        assertThat(entity, hasJsonListAt("$.children"));
+        assertThat(entity, hasJsonValueAt("$.children[0]").of("default"));
+    }
+
+
+    @Test
+    public void shouldShowContainerDefaultCapability() throws Exception
+    {
+        HttpResponse response = client.request(GET, "/cdmi_capabilities/container/default/")
+                .withAccept("application/cdmi-capability")
+                .send();
+
+
+        assertThat(response.getStatusLine(), hasStatusCode(200));
+
+        Header[] headers = response.getAllHeaders();
+        assertThat(headers, hasHeader("Content-Type", "application/cdmi-capability"));
+
+        HttpEntity entity = response.getEntity();
+        assertThat(entity, hasJsonStringAt("$.objectID"));
+        assertThat(entity, hasJsonStringAt("$.parentID"));
+        assertThat(entity, hasJsonValueAt("$.parentURI").of("cdmi_capabilities/container"));
+        assertThat(entity, not(hasJsonListAt("$.children")));
+        assertThat(entity, hasJsonObjectAt("$.capabilities"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_read_metadata").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_create_dataobject").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_post_dataobject").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_create_container").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_modify_metadata").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_list_children").of("true"));
+    }
+
+    @Test
+    public void shouldShowDataObjectCapability() throws Exception
+    {
+        HttpResponse response = client.request(GET, "/cdmi_capabilities/dataobject/")
+                .withAccept("application/cdmi-capability")
+                .send();
+
+
+        assertThat(response.getStatusLine(), hasStatusCode(200));
+
+        Header[] headers = response.getAllHeaders();
+        assertThat(headers, hasHeader("Content-Type", "application/cdmi-capability"));
+
+        HttpEntity entity = response.getEntity();
+        assertThat(entity, hasJsonStringAt("$.objectID"));
+        assertThat(entity, hasJsonStringAt("$.parentID"));
+        assertThat(entity, hasJsonValueAt("$.parentURI").of("cdmi_capabilities/"));
+        assertThat(entity, not(hasJsonListAt("$.children")));
+        assertThat(entity, hasJsonObjectAt("$.capabilities"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_read_metadata").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_read_value").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_modify_metadata").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_modify_value").of("true"));
+        assertThat(entity, hasJsonValueAt("$.capabilities.cdmi_delete_dataobject").of("true"));
     }
 }


### PR DESCRIPTION
Motivation:

The current set of functional tests only verifies the root capability
object, but currently the code also provides information bound to
container, container/default and dataobject capability objects, which
are not tested.

Modification:

Add functional tests to exercise all capability objects currently
supported.

Result:

Better code coverage
